### PR TITLE
macOS is writing credentials to disk too

### DIFF
--- a/Rubrik/public/New-ConfigJson.ps1
+++ b/Rubrik/public/New-ConfigJson.ps1
@@ -24,10 +24,16 @@ function New-ConfigJson {
         $null = New-Item -Path './config' -ItemType Directory
     }
 
-    $CurrentConfig = [pscustomobject]$MyInvocation.BoundParameters
-    $CurrentConfig.TestIp = $CurrentConfig.TestIp.ToString()
-    $CurrentConfig.TestGateway = $CurrentConfig.TestGateway.ToString()
-    
+    $CurrentConfig = [pscustomobject]@{"virtualMachines" = ,@{
+        name = $Name
+        mountName = $MountName
+        testIp = $TestIp.ToString()
+        testNetwork = $TestNetwork
+        testSubnet = $TestSubnet
+        testGateway = $TestGateway.ToString()
+        tasks = $Tasks
+    }}
+        
     $CurrentConfig |
     ConvertTo-Json -Depth 3 | 
     Set-Content -Path (Join-Path './config' $ConfigFilePath)

--- a/Rubrik/public/New-ConfigJson.ps1
+++ b/Rubrik/public/New-ConfigJson.ps1
@@ -32,6 +32,7 @@ function New-ConfigJson {
         testSubnet = $TestSubnet
         testGateway = $TestGateway.ToString()
         tasks = $Tasks
+        guestCred = $GuestCred
     }}
         
     $CurrentConfig |

--- a/Rubrik/public/New-SecureCredential.ps1
+++ b/Rubrik/public/New-SecureCredential.ps1
@@ -17,7 +17,7 @@ function New-SecureCredential {
     } 
 
     switch (Get-PowerShellVersion) {
-        'Windows' {
+        { 'Windows' -or 'macOS' } {
             if (-not (Test-FolderStructure -Credential)) {
                 $null = New-Item -Path './credential' -ItemType Directory
             }
@@ -26,9 +26,6 @@ function New-SecureCredential {
                 $Credential = (Get-Item variable:$_).Value
                 $Credential | Export-Clixml -Path $(Join-Path $Path "$_.xml")
             }
-        }
-        'macOS' {
-
         }
         default {Write-Error 'Current OS platform not supported '}
     }


### PR DESCRIPTION
Now Windows and macOS are using the same code to write the credentials to disk.

# Description

Running `New-BuildConfiguration`  or `New-SecureCredential` on macOS does not write the credentials to disk. This simple code change fixes this.

## Related Issue

Issue 2

## Motivation and Context

Not able to use `New-BuildConfiguration`  or `New-SecureCredential` on macOS

## How Has This Been Tested?

Tested on macOS Mojave and Windows 10

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **[CONTRIBUTION](http://rubrikinc.github.io/PowerShell-Module/documentation/contribution.html)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
